### PR TITLE
Make ssh_config processing more robust

### DIFF
--- a/cmc
+++ b/cmc
@@ -73,12 +73,11 @@ action_check_set() {
 config_hosts_list() {
     # Extract ControlMaster hosts from SSH config
     local _result=$(awk \
-            'tolower($0) ~ /^[[:space:]]*(host|controlmaster)[[:space:]]+/ {
-                if (tolower($1) == "host")
-                    host=$2
-                if (tolower($1) == "controlmaster")
-                    print host
-            }' ${ssh_config})
+        'tolower($0) ~ /^[[:space:]]*host[[:space:]]+/ {
+            host=$2; next }
+         tolower($0) ~ /^[[:space:]]*controlmaster[[:space:]]+(yes|auto)/ {
+            print host; next }
+        ' ${ssh_config})
     if [[ -n "${_result}" ]]
     then
         echo "${_result}"


### PR DESCRIPTION
* We should process only hosts that have
  ControlMaster explicitly set to 'auto' or 'yes'
  and ignore all other options (no, ask, autoask)
  Otherwise it will break things, notably if you set
  'ControlMaster no' to the entry for 'Host *'
* Awk script gently rewritten.